### PR TITLE
Disable number parsing while printing jobs in roro ps.

### DIFF
--- a/roro/cli.py
+++ b/roro/cli.py
@@ -137,7 +137,7 @@ def ps(all):
         total_time = datetime.timedelta(total_time.days, total_time.seconds)
         command = " ".join(job["details"]["command"])
         rows.append([job['jobid'], job['status'], h.datestr(start), str(total_time), job['instance_type'], h.truncate(command, 50)])
-    print(tabulate(rows, headers=['JOBID', 'STATUS', 'WHEN', 'TIME', 'INSTANCE TYPE', 'CMD']))
+    print(tabulate(rows, headers=['JOBID', 'STATUS', 'WHEN', 'TIME', 'INSTANCE TYPE', 'CMD'], disable_numparse=True))
 
 @cli.command(name='ps:restart')
 @click.argument('name')


### PR DESCRIPTION
tabulate function interprets 909886e3 as a number, to disable this use
desable_number argument.

>>> import tabulate
>>> print(tabulate.tabulate([["909886e3", "hello", "world"]]))
-----------  -----  -----
9.09886e+08  hello  world
-----------  -----  -----

>>> print(tabulate.tabulate([["909886e3", "hello", "world"]],
>>> disable_numparse=True))
--------  -----  -----
909886e3  hello  world
--------  -----  -----