### PR TITLE
Fixes build errors by improving cross version compatibility

### DIFF
--- a/roro/auth.py
+++ b/roro/auth.py
@@ -64,11 +64,7 @@ class netrc(_netrc):
         # work-around to fix that
         if file is None:
             file = self.find_default_file()
-
-        if PY2:
-            _netrc.__init__(self, file=file)
-        else:
-            super().__init__(file=file)
+        _netrc.__init__(self, file=file)
 
     def find_default_file(self):
         filename = "_netrc" if sys.platform == 'win32' else ".netrc"

--- a/roro/auth.py
+++ b/roro/auth.py
@@ -64,11 +64,15 @@ class netrc(_netrc):
         # work-around to fix that
         if file is None:
             file = self.find_default_file()
-        super().__init__(file=file)
+
+        if PY2:
+            _netrc.__init__(self, file=file)
+        else:
+            super().__init__(file=file)
 
     def find_default_file(self):
         filename = "_netrc" if sys.platform == 'win32' else ".netrc"
-        p = pathlib.Path.home().joinpath(filename)
+        p = pathlib.Path(os.path.expanduser('~')).joinpath(filename)
         return str(p)
 
     def __repr__(self):


### PR DESCRIPTION
- Reverts to old style parent class instantiation                                                                                                                      
- Uses os.path.expanduser('~') to get home directory path. Also, cross-platform and cross-python version compatible.